### PR TITLE
[NO-ISSUE] Add Matrix Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.3.1
+
+- Added a new `matrix()`-method that allows access to a copy of the underlying bit matrix
+
 # Version 1.3.0
 
 - Added a new `distance`-method to compute the hamming distance between hashes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imghash"
-version = "1.3.0"
+version = "1.3.1"
 
 description = "Image hashing for Rust"
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ let difference = difference_hash(path);
 let perceptual = perceptual_hash(path);
 ```
 
-Each of these functions return a `Result<ImageHash, String>`-type. The `ImageHash` object is essentially a container for the encoded bit matrix of the image (learn more [here](./docs/encoding.md)). The `ImageHash` can be encoded into hexadecimal string by calling the encode method:
+Each of these functions return a `Result<ImageHash, String>`-type. The `ImageHash` object is essentially a container for the encoded bit matrix of the image (learn more [here](./docs/encoding.md)). The `ImageHash` can be encoded into hexadecimal string by calling the `encode`-method:
 
 ```rust
 let res: String = hash.encode();
@@ -71,9 +71,9 @@ This can produce an error if the hashes are not of the same size.
 
 ### Custom Hashers
 
-If you need more flexibility, for example getting a larger bit matrix, you can use a custom Hasher instance.
+If you need more flexibility, for example computing a larger bit matrix than the default, you can use a custom `Hasher`.
 
-For each hash type the crate provides a custom hasher, here for the example we will use the `AverageHasher`:
+For each hash type the crate provides a custom hasher, for the example here we will use the `AverageHasher`:
 
 ```rust
 use imghash::{average::AverageHasher};
@@ -88,7 +88,7 @@ let hasher = AverageHasher {
 let hash = hasher.hash_from_path(path);
 ```
 
-Hasher instances also allow you to create hashes for already loaded images:
+`Hasher`-instances also allow you to create hashes for already loaded images:
 
 ```rust
 let img = ImageReader::open(...);

--- a/src/imghash.rs
+++ b/src/imghash.rs
@@ -19,6 +19,11 @@ impl ImageHash {
         ImageHash { matrix }
     }
 
+    /// Returns a copy of the underlying matrix that represents the [`ImageHash`].
+    pub fn matrix(&self) -> Vec<Vec<bool>> {
+        self.matrix.clone()
+    }
+
     /// Flattens the bit matrix that represents the [`ImageHash`] into a single vector.
     pub fn flatten(&self) -> Vec<bool> {
         self.matrix.iter().flatten().copied().collect()
@@ -33,7 +38,7 @@ impl ImageHash {
     /// number of bits that differ between the two hashes.
     pub fn distance(&self, other: &ImageHash) -> Result<usize, String> {
         if self.shape() != other.shape() {
-            return Err("Cannot subtract hashes of different sizes".to_string());
+            return Err("Cannot compute distance of hashes with different sizes".to_string());
         }
 
         Ok(self
@@ -172,7 +177,7 @@ mod tests {
     // NEW
 
     #[test]
-    fn test_image_new_with_valid_matrix() {
+    fn test_image_hash_new_with_valid_matrix() {
         // Arrange
         let hash = ImageHash::new(vec![vec![false, true], vec![true, false]]);
 
@@ -187,9 +192,20 @@ mod tests {
 
     #[test]
     #[should_panic]
-    fn test_image_new_with_invalid_matrix() {
+    fn test_image_hash_new_with_invalid_matrix() {
         // should panic as the second row is longer than the first one
         let _ = ImageHash::new(vec![vec![false, true], vec![true, false, false]]);
+    }
+
+    // MATRIX
+
+    #[test]
+    fn test_image_hash_get_matrix() {
+        // Arrange
+        let hash = ImageHash::new(vec![vec![false, true], vec![true, false]]);
+
+        // Assert
+        assert_eq!(hash.matrix(), vec![vec![false, true], vec![true, false]],);
     }
 
     // FLATTEN
@@ -498,7 +514,7 @@ mod tests {
         // Assert
         match distance {
             Ok(_) => panic!("Should not have succeeded"),
-            Err(e) => assert_eq!(e, "Cannot subtract hashes of different sizes"),
+            Err(e) => assert_eq!(e, "Cannot compute distance of hashes with different sizes"),
         }
     }
 }


### PR DESCRIPTION
# Overview

This PR adds a new `matrix()`-method than can be used to access a copy of the underlying bit matrix. This is required to fix some downstream packages that depend on the access of the matrix.

## Checklist

- [x] Tests
- [x] Documentation
- [ ] Updated Changelog
- [ ] Updated Version in Cargo.toml

