### PR TITLE
Chore: bumps internal image crate to 0.25.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.4.0
+
+- Updated the internal image crate to version 0.25.6
+
 # Version 1.3.1
 
 - Added a new `matrix()`-method that allows access to a copy of the underlying bit matrix

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imghash"
-version = "1.3.1"
+version = "1.4.0"
 
 description = "Image hashing for Rust"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ repository = "https://github.com/YannickAlex07/imghash-rs"
 edition = "2021"
 
 [dependencies]
-image = { version = "0.24.8", features = ["rayon"] }
+image = { version = "0.25.6", features = ["rayon"] }
 rayon = "1.10.0"


### PR DESCRIPTION
# Overview

This PR bumps the internal image crate to version 0.25.6 since the version has diverged between releases.

## Checklist

- [ X] Tests
- [ X] Documentation
- [ X] Updated Changelog
- [ X] Updated Version in Cargo.toml

## Related Tasks

<!-- Link the task that is related to this if applicable. If not, remove this section. -->

* 

