### PR TITLE
[#21] Replace outdated `image::io:: ImageReader ` imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Version 1.5.0
+
+- Updated depracted `image::io::ImageReader` imports
+
 # Version 1.4.0
 
 - Updated the internal image crate to version 0.25.6

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "imghash"
-version = "1.4.0"
+version = "1.5.0"
 
 description = "Image hashing for Rust"
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: "2"
+
+comment:
+  layout: "header, files, condensed_footer"

--- a/src/average.rs
+++ b/src/average.rs
@@ -54,7 +54,7 @@ impl ImageOps for AverageHasher {}
 mod tests {
     use std::path::Path;
 
-    use image::io::Reader as ImageReader;
+    use image::ImageReader;
 
     use super::*;
 

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -49,7 +49,7 @@ impl ImageOps for DifferenceHasher {}
 mod tests {
     use std::path::Path;
 
-    use image::io::Reader as ImageReader;
+    use image::ImageReader;
 
     use super::*;
 

--- a/src/imageops.rs
+++ b/src/imageops.rs
@@ -66,7 +66,7 @@ pub trait ImageOps {
 mod tests {
     use super::*;
 
-    use image::io::Reader as ImageReader;
+    use image::ImageReader;
     use std::path::Path;
 
     pub struct Converter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ pub trait ImageHasher {
     ///
     /// The generated image hash.
     fn hash_from_path(&self, path: &Path) -> Result<ImageHash, ImageError> {
-        match image::io::Reader::open(path)?.decode() {
+        match image::ImageReader::open(path)?.decode() {
             Ok(img) => Ok(self.hash_from_img(&img)),
             Err(e) => Err(e),
         }

--- a/src/perceptual.rs
+++ b/src/perceptual.rs
@@ -80,7 +80,7 @@ impl ImageOps for PerceptualHasher {}
 mod tests {
     use std::path::Path;
 
-    use image::io::Reader as ImageReader;
+    use image::ImageReader;
 
     use super::*;
 


### PR DESCRIPTION
# Overview

This PR replaces the outdated `image::io::ImageReader` imports with the new `image::ImageReader` imports.

## Checklist

- [x] Tests
- [x] Documentation
- [x] Updated Changelog
- [x] Updated Version in Cargo.toml if needed

## Related Tasks

<!-- Link the task that is related to this if applicable. If not, remove this section. -->

* #21 

