### PR TITLE
Rebase on bit vector instead.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Version 1.5.0
 
-- Updated depracted `image::io::ImageReader` imports
+- Updated deprecated `image::io::ImageReader` imports
+- Deprecated `ImageHash::new`
+- The `ImageHash` type is now backed by a bit vector instead of a `bool` matrix. The `matrix()` method now creates a new `Vec<Vec<bool>>` from the bit vector, which is very inefficient.
 
 # Version 1.4.0
 
@@ -32,4 +34,4 @@
 
 - Added hashers for Average, Difference and Perceptual hashes
 - Added utility functions for the hashers
-- Added ImageHash object for encoding and decoding bit matricies
+- Added ImageHash object for encoding and decoding bit matrices

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Updated deprecated `image::io::ImageReader` imports
 - Deprecated `ImageHash::new`
 - The `ImageHash` type is now backed by a bit vector instead of a `bool` matrix. The `matrix()` method now creates a new `Vec<Vec<bool>>` from the bit vector, which is very inefficient.
+- All internal usage of `Vec<Vec<...>>` have been eliminated.
 
 # Version 1.4.0
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,5 @@ edition = "2021"
 
 [dependencies]
 image = { version = "0.25.6", features = ["rayon"] }
+bitvec = "1.0.0"
 rayon = "1.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ edition = "2021"
 
 [dependencies]
 image = { version = "0.25.6", features = ["rayon"] }
-bitvec = "1.0.0"
+bitvec = { version = "1.0.0", default-features = false, features = ["alloc"] }
 rayon = "1.10.0"

--- a/src/average.rs
+++ b/src/average.rs
@@ -14,7 +14,7 @@ pub struct AverageHasher {
 
 impl ImageHasher for AverageHasher {
     fn hash_from_img(&self, img: &image::DynamicImage) -> ImageHash {
-        let converted = self.convert(img, self.width, self.height, &self.color_space);
+        let converted = self.convert(img, self.width, self.height, self.color_space);
         let mean = converted
             .as_bytes()
             .to_vec()

--- a/src/average.rs
+++ b/src/average.rs
@@ -22,7 +22,7 @@ impl ImageHasher for AverageHasher {
             .fold(0, |acc, x| acc + *x as usize)
             / (self.width as usize * self.height as usize);
 
-        ImageHash::from_stream(
+        ImageHash::from_bool_iter(
             converted.as_bytes().iter().map(|&p| p as usize > mean),
             self.width,
             self.height,

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -12,7 +12,7 @@ pub struct DifferenceHasher {
 
 impl ImageHasher for DifferenceHasher {
     fn hash_from_img(&self, img: &image::DynamicImage) -> ImageHash {
-        let converted = self.convert(img, self.width + 1, self.height, &self.color_space);
+        let converted = self.convert(img, self.width + 1, self.height, self.color_space);
 
         // we will compute the differences on this matrix
         let compare_matrix: Box<[Box<[u8]>]> = converted

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -22,7 +22,7 @@ impl ImageHasher for DifferenceHasher {
             .collect::<Vec<_>>()
             .into_boxed_slice();
 
-        ImageHash::from_stream(
+        ImageHash::from_bool_iter(
             compare_matrix
                 .iter()
                 .flat_map(|row| row.windows(2).map(|window| window[0] < window[1])),

--- a/src/difference.rs
+++ b/src/difference.rs
@@ -1,5 +1,4 @@
 use crate::{imageops::ImageOps, ColorSpace, ImageHash, ImageHasher};
-use bitvec::prelude::*;
 
 pub struct DifferenceHasher {
     /// The target width of the matrix
@@ -18,29 +17,18 @@ impl ImageHasher for DifferenceHasher {
         // we will compute the differences on this matrix
         let compare_matrix: Box<[Box<[u8]>]> = converted
             .as_bytes()
-            .to_vec()
             .chunks((self.width + 1) as usize)
             .map(|x| x.to_vec().into_boxed_slice())
             .collect::<Vec<_>>()
             .into_boxed_slice();
 
-        let size = (self.width as usize * self.height as usize + 7) / 8;
-
-        let mut bits = vec![0_u8; size];
-        let data = bits.view_bits_mut::<Msb0>();
-
-        let mut x = size * 8 - (self.width as usize * self.height as usize);
-
-        for row in &compare_matrix {
-            row.windows(2)
-                .map(|window| window[0] < window[1])
-                .for_each(|v| {
-                    data.set(x, v);
-                    x += 1;
-                });
-        }
-
-        ImageHash::new_from_bit_vector(bits, self.width, self.height)
+        ImageHash::from_stream(
+            compare_matrix
+                .iter()
+                .flat_map(|row| row.windows(2).map(|window| window[0] < window[1])),
+            self.width,
+            self.height,
+        )
     }
 }
 

--- a/src/imageops.rs
+++ b/src/imageops.rs
@@ -1,7 +1,9 @@
 use image::{imageops::FilterType, DynamicImage, GenericImageView, GrayImage};
 use rayon::prelude::*;
 
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy, Default)]
 pub enum ColorSpace {
+    #[default]
     REC709,
     REC601,
 }
@@ -15,11 +17,11 @@ pub trait ImageOps {
     ///
     /// # Returns
     /// * The converted dynamic image
-    fn grayscale(&self, img: &DynamicImage, space: &ColorSpace) -> DynamicImage {
+    fn grayscale(&self, img: &DynamicImage, color_space: ColorSpace) -> DynamicImage {
         let mut buffer = GrayImage::new(img.width(), img.height());
 
         let coefficients: [f64; 3];
-        match space {
+        match color_space {
             ColorSpace::REC709 => coefficients = [0.2126, 0.7152, 0.0722],
             ColorSpace::REC601 => coefficients = [0.299, 0.587, 0.114],
         }
@@ -53,7 +55,7 @@ pub trait ImageOps {
         img: &DynamicImage,
         width: u32,
         height: u32,
-        color_space: &ColorSpace,
+        color_space: ColorSpace,
     ) -> DynamicImage {
         let filter = FilterType::Lanczos3;
 
@@ -96,7 +98,7 @@ mod tests {
         let converter = Converter {};
 
         // Act
-        let grayscale = converter.grayscale(&test_img, &ColorSpace::REC601);
+        let grayscale = converter.grayscale(&test_img, ColorSpace::REC601);
 
         // Assert
         assert_eq!(grayscale, grayscale_img);
@@ -118,7 +120,7 @@ mod tests {
         let converter = Converter {};
 
         // Act
-        let converted = converter.convert(&test_img, 32, 32, &ColorSpace::REC601);
+        let converted = converter.convert(&test_img, 32, 32, ColorSpace::REC601);
 
         // Assert
         assert_eq!(converted, converted_img);
@@ -140,7 +142,7 @@ mod tests {
         let converter = Converter {};
 
         // Act
-        let grayscale = converter.grayscale(&test_img, &ColorSpace::REC709);
+        let grayscale = converter.grayscale(&test_img, ColorSpace::REC709);
 
         // Assert
         assert_eq!(grayscale, grayscale_img);
@@ -162,7 +164,7 @@ mod tests {
         let converter = Converter {};
 
         // Act
-        let converted = converter.convert(&test_img, 32, 32, &ColorSpace::REC709);
+        let converted = converter.convert(&test_img, 32, 32, ColorSpace::REC709);
 
         // Assert
         assert_eq!(converted, converted_img);

--- a/src/imghash.rs
+++ b/src/imghash.rs
@@ -131,14 +131,16 @@ impl ImageHash {
 
         let mut result = Vec::new();
 
-        for byte in self.data.as_raw_slice().iter() {
-            write!(&mut result, "{:02x}", byte).unwrap();
-        }
-
         let nibbles = (self.width * self.height + 3) / 4;
+        let odd = nibbles % 2 == 1;
 
-        if nibbles % 2 == 1 {
-            result.remove(0);
+        for byte in self.data.as_raw_slice().iter() {
+            // Skip the leading '0' if the number of nibbles is odd
+            if odd && result.is_empty() {
+                write!(&mut result, "{:01x}", byte).unwrap();
+            } else {
+                write!(&mut result, "{:02x}", byte).unwrap();
+            }
         }
 
         String::from_utf8(result).unwrap()

--- a/src/math.rs
+++ b/src/math.rs
@@ -88,12 +88,13 @@ pub fn dct2_over_matrix(input: &Vec<Vec<f64>>, axis: Axis) -> Vec<Vec<f64>> {
 /// # Returns
 /// * Returns a float that represents the median
 /// * Returns `None` if `input` is empty
-pub fn median(input: &[f64]) -> Option<f64> {
-    if input.is_empty() {
+pub fn median(input: impl IntoIterator<Item = f64>) -> Option<f64> {
+    let mut sorted = input.into_iter().collect::<Vec<_>>();
+
+    if sorted.is_empty() {
         return None;
     }
 
-    let mut sorted = input.to_vec();
     sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
 
     let mid = sorted.len() / 2;
@@ -276,7 +277,7 @@ mod tests {
         let input = vec![3., 2., 1., 4.];
 
         // Act
-        let result = median(&input);
+        let result = median(input);
 
         // Assert
         assert_eq!(result, Some(2.5));
@@ -288,7 +289,7 @@ mod tests {
         let input = vec![3., 4., 1., 2., 5.];
 
         // Act
-        let result = median(&input);
+        let result = median(input);
 
         // Assert
         assert_eq!(result, Some(3.));
@@ -300,7 +301,7 @@ mod tests {
         let input = vec![];
 
         // Act
-        let result = median(&input);
+        let result = median(input);
 
         // Assert
         assert_eq!(result, None);

--- a/src/perceptual.rs
+++ b/src/perceptual.rs
@@ -48,7 +48,7 @@ impl ImageHasher for PerceptualHasher {
         // compute the median over the flattened matrix
         let median = median(scaled_matrix.iter().copied()).unwrap();
 
-        ImageHash::from_stream(
+        ImageHash::from_bool_iter(
             scaled_matrix.into_iter().map(|pixel| pixel > median),
             self.width,
             self.height,

--- a/src/perceptual.rs
+++ b/src/perceptual.rs
@@ -24,7 +24,7 @@ impl ImageHasher for PerceptualHasher {
             img,
             self.width * self.factor,
             self.height * self.factor,
-            &self.color_space,
+            self.color_space,
         );
 
         // convert the higher frequency image to a matrix of f64

--- a/src/perceptual.rs
+++ b/src/perceptual.rs
@@ -1,6 +1,6 @@
 use crate::{
     imageops::ImageOps,
-    math::{dct2_over_matrix, median, Axis},
+    math::{dct2_over_matrix_in_place, median, Axis},
     ColorSpace, ImageHash, ImageHasher,
 };
 
@@ -26,7 +26,7 @@ impl ImageHasher for PerceptualHasher {
         let high_freq = self.convert(img, width, height, self.color_space);
 
         // convert the higher frequency image to a matrix of f64
-        let high_freq_bytes = high_freq
+        let mut dct_matrix = high_freq
             .as_bytes()
             .into_iter()
             .copied()
@@ -34,11 +34,8 @@ impl ImageHasher for PerceptualHasher {
             .collect::<Vec<_>>();
 
         // now we compute the DCT for each column and then for each row
-        let dct_matrix = dct2_over_matrix(
-            &dct2_over_matrix(&high_freq_bytes, width as usize, Axis::Column),
-            width as usize,
-            Axis::Row,
-        );
+        dct2_over_matrix_in_place(&mut dct_matrix, width as usize, Axis::Column);
+        dct2_over_matrix_in_place(&mut dct_matrix, width as usize, Axis::Row);
 
         // now we crop the dct matrix to the actual target width and height
         let scaled_matrix = dct_matrix


### PR DESCRIPTION
This PR changes the backing data store for `ImageHash` to a bit-vector instead of `Vec<Vec<bool>>`.

All public API's remain unchanged, although methods such as `matrix()`, `flatten()` etc. are marked as deprecated since they re-create the `Vec<Vec<bool>>` behind the scene and are inefficient.

I benchmarked the change and it is _substantially_ faster.

